### PR TITLE
Bubbling Error reason when verifying

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis-guild/zodiac-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn@gnosisguild.org>",
   "license": "LGPL-3.0+",

--- a/src/artifact/internal/etherscan.ts
+++ b/src/artifact/internal/etherscan.ts
@@ -76,13 +76,14 @@ export async function verifySourceCode({
     },
     body: parameters.toString(),
   });
-  const { status, message } = (await response.json()) as {
+  const { status, message, result } = (await response.json()) as {
     status: number;
     message: string;
+    result: string;
   };
 
   if (!isOk(status)) {
-    throw new Error(`Verification Error: ${status} ${message}`);
+    throw new Error(`Verifying SourceCode: ${message} ${result}`);
   }
 
   return {


### PR DESCRIPTION
This PR enhances error transparency for verification failures.

Different block explorers have varying configs regarding apikey requirements. Previously, we used a generic price call to determine if a key was invalid. However, for example block explorers on testnets or gnosisscan, do not require a key for reads. This causes our check to not detect an invalid key.

Therefore, we now display more info when the actual verify call fails.

Note: This PR also includes a version bump in preparation for the upcoming release.






