### PR TITLE
Fix missing library references in Zodiac Core mastercopy JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis-guild/zodiac-core",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn@gnosisguild.org>",
   "license": "LGPL-3.0+",

--- a/src/artifact/internal/linkBuildArtifact.ts
+++ b/src/artifact/internal/linkBuildArtifact.ts
@@ -101,9 +101,8 @@ function linkCompilerInput(
   compilerInput: any,
   mastercopies: Record<string, Record<string, MastercopyArtifact>>
 ): any {
+  const result = { ...compilerInput };
   for (const libraryPath of Object.keys(artifact.linkReferences)) {
-    compilerInput.settings.libraries[libraryPath] =
-      compilerInput.settings.libraries[libraryPath] || {};
     for (const libraryName of Object.keys(
       artifact.linkReferences[libraryPath]
     )) {
@@ -115,13 +114,15 @@ function linkCompilerInput(
 
       assert(isAddress(libraryAddress));
 
-      compilerInput.settings = {
-        ...compilerInput.settings,
+      result.settings = {
+        ...result.settings,
         libraries: {
-          ...compilerInput.settings.libraries,
+          ...result.settings.libraries,
           [libraryPath]: { [libraryName]: libraryAddress },
         },
       };
     }
   }
+
+  return result;
 }

--- a/src/artifact/internal/linkBuildArtifact.ts
+++ b/src/artifact/internal/linkBuildArtifact.ts
@@ -1,0 +1,127 @@
+import assert from "assert";
+import { isAddress } from "ethers";
+
+import { BuildArtifact, MastercopyArtifact } from "../../types";
+
+/**
+ * Resolves library links in a build artifact
+ *
+ */
+export default function linkBuildArtifact({
+  artifact,
+  contractVersion,
+  minimalCompilerInput,
+  mastercopies,
+}: {
+  artifact: BuildArtifact;
+  contractVersion: string;
+  minimalCompilerInput?: string;
+  mastercopies: Record<string, Record<string, MastercopyArtifact>>;
+}): BuildArtifact {
+  const bytecode = linkBytecode(artifact, contractVersion, mastercopies);
+  const compilerInput = linkCompilerInput(
+    artifact,
+    contractVersion,
+    minimalCompilerInput || artifact.compilerInput,
+    mastercopies
+  );
+
+  return {
+    ...artifact,
+    bytecode,
+    compilerInput,
+  };
+}
+
+/**
+ * Replaces library references in the bytecode with actual deployed addresses.
+ *
+ * This function scans the bytecode and replaces placeholder references
+ * to libraries with their actual on-chain addresses. It ensures that
+ * the library addresses are valid and properly formatted.
+ *
+ * @param {string} bytecode - The bytecode that may contain library references.
+ * @param {Record<string, any>} linkReferences - References to libraries, as returned by the compiler.
+ * @param {Record<string, string>} libraryAddresses - A map of library names to their deployed addresses.
+ * @returns {string} - The updated bytecode with library references replaced by actual addresses.
+ *
+ * @throws {Error} - Throws if a library address is missing or incorrectly formatted.
+ */
+function linkBytecode(
+  artifact: BuildArtifact,
+  contractVersion: string,
+  mastercopies: Record<string, Record<string, MastercopyArtifact>>
+): string {
+  let bytecode = artifact.bytecode;
+
+  for (const libraryPath of Object.keys(artifact.linkReferences)) {
+    for (const libraryName of Object.keys(
+      artifact.linkReferences[libraryPath]
+    )) {
+      console.log(`libraryPath ${libraryPath} libraryName ${libraryName}`);
+
+      if (
+        !mastercopies[libraryName] ||
+        !mastercopies[libraryName][contractVersion]
+      ) {
+        throw new Error(
+          `Could not link ${libraryName} for ${artifact.contractName}`
+        );
+      }
+
+      let { address: libraryAddress } =
+        mastercopies[libraryName][contractVersion];
+
+      assert(isAddress(libraryAddress));
+
+      for (const { length, start: offset } of artifact.linkReferences[
+        libraryPath
+      ][libraryName]) {
+        assert(length == 20);
+
+        // the offset is in bytes, and does not account for the trailing 0x
+        const left = 2 + offset * 2;
+        const right = left + length * 2;
+
+        bytecode = `${bytecode.slice(0, left)}${libraryAddress.slice(2).toLowerCase()}${bytecode.slice(right)}`;
+
+        console.log(
+          `Replaced library reference at ${offset} with address ${libraryAddress}`
+        );
+      }
+    }
+  }
+
+  return bytecode;
+}
+
+function linkCompilerInput(
+  artifact: BuildArtifact,
+  contractVersion: string,
+  compilerInput: any,
+  mastercopies: Record<string, Record<string, MastercopyArtifact>>
+): any {
+  for (const libraryPath of Object.keys(artifact.linkReferences)) {
+    compilerInput.settings.libraries[libraryPath] =
+      compilerInput.settings.libraries[libraryPath] || {};
+    for (const libraryName of Object.keys(
+      artifact.linkReferences[libraryPath]
+    )) {
+      const libraryAddress =
+        mastercopies[libraryName]?.[contractVersion]?.address;
+      if (!libraryAddress) {
+        continue;
+      }
+
+      assert(isAddress(libraryAddress));
+
+      compilerInput.settings = {
+        ...compilerInput.settings,
+        libraries: {
+          ...compilerInput.settings.libraries,
+          [libraryPath]: { [libraryName]: libraryAddress },
+        },
+      };
+    }
+  }
+}

--- a/src/artifact/writeMastercopyFromBuild.ts
+++ b/src/artifact/writeMastercopyFromBuild.ts
@@ -49,7 +49,7 @@ export default function writeMastercopyFromBuild({
   compilerInput?: any;
   buildDirPath?: string;
   mastercopyArtifactsFile?: string;
-}) {
+}): MastercopyArtifact {
   const buildArtifact = getBuildArtifact(contractName, buildDirPath);
 
   const mastercopies = existsSync(mastercopyArtifactsFile)
@@ -111,4 +111,6 @@ export default function writeMastercopyFromBuild({
     JSON.stringify(sortedMastercopies, null, 2),
     "utf8"
   );
+
+  return mastercopyArtifact;
 }

--- a/src/artifact/writeMastercopyFromBuild.ts
+++ b/src/artifact/writeMastercopyFromBuild.ts
@@ -66,6 +66,23 @@ export default function writeMastercopyFromBuild({
     mastercopies
   );
 
+  const compilerInput = minimalCompilerInput || buildArtifact.compilerInput;
+  compilerInput.settings = compilerInput.settings || {};
+  compilerInput.settings.libraries = compilerInput.settings.libraries || {};
+  for (const libraryPath of Object.keys(buildArtifact.linkReferences)) {
+    compilerInput.settings.libraries[libraryPath] =
+      compilerInput.settings.libraries[libraryPath] || {};
+    for (const libraryName of Object.keys(
+      buildArtifact.linkReferences[libraryPath]
+    )) {
+      const libraryAddress =
+        mastercopies[libraryName]?.[contractVersion]?.address;
+      if (libraryAddress) {
+        compilerInput.settings.libraries[libraryPath][libraryName] =
+          libraryAddress;
+      }
+    }
+  }
   const mastercopyArtifact: MastercopyArtifact = {
     contractName,
     sourceName: buildArtifact.sourceName,
@@ -82,7 +99,7 @@ export default function writeMastercopyFromBuild({
     constructorArgs,
     salt,
     abi: buildArtifact.abi,
-    compilerInput: minimalCompilerInput || buildArtifact.compilerInput,
+    compilerInput,
   };
 
   const nextMastercopies = {

--- a/src/artifact/writeMastercopyFromExplorer.ts
+++ b/src/artifact/writeMastercopyFromExplorer.ts
@@ -106,4 +106,6 @@ export default async function writeMastercopyFromExplorer({
     JSON.stringify(sortedMastercopies, null, 2),
     "utf8"
   );
+
+  return mastercopyArtifact;
 }


### PR DESCRIPTION


## Description

This PR addresses the issue where `zodiac-core` was not adding library references in the mastercopy JSON. Specifically, the problem was occurring during the OZ contract verification process, where the expected library addresses were missing in the generated artifact.


Example of missing library reference:
```json
"libraries": {
  "contracts/MultisendEncoder.sol": {
    "MultisendEncoder": "0xB48669C9c27A3bE7219755B82E5d3567a0f4D21E"
  }
}
```

## Solution
The following changes have been implemented:
- Added logic to ensure that library references and their respective addresses are included in the `compilerInput.settings.libraries` field of the mastercopy JSON.
- Replaced placeholder references with the actual on-chain addresses of deployed libraries in the bytecode.
- Updated the mastercopy artifact structure to properly include these references in future deployments.

### Testing
- Verified that the new process correctly replaces library references and updates the mastercopy artifacts.
- Ensured that the libraries section is added to the `compilerInput` for contracts with linked libraries.
