### PR TITLE
feat: introduce Lisk, Lisk Sepolia, Bob, and Bob Sepolia chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ yarn-error.log
 .docusaurus
 .idea
 .yarn
+.vscode/settings.json
+/.vscode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis-guild/zodiac-core",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn@gnosisguild.org>",
   "license": "LGPL-3.0+",

--- a/src/artifact/internal/chainConfig.ts
+++ b/src/artifact/internal/chainConfig.ts
@@ -112,6 +112,14 @@ export const chainConfig = [
     },
   },
   {
+    network: "lisk",
+    chainId: 1135,
+    urls: {
+      apiURL: "https://blockscout.lisk.com/api",
+      browserURL: "https://blockscout.lisk.com",
+    },
+  },
+  {
     network: "moonbeam",
     chainId: 1284,
     urls: {
@@ -149,6 +157,14 @@ export const chainConfig = [
     urls: {
       apiURL: "https://api-testnet.ftmscan.com/api",
       browserURL: "https://testnet.ftmscan.com",
+    },
+  },
+  {
+    network: "lisk-sepolia",
+    chainId: 4202,
+    urls: {
+      apiURL: "https://sepolia-blockscout.lisk.com/api",
+      browserURL: "https://sepolia-blockscout.lisk.com",
     },
   },
   {
@@ -200,6 +216,14 @@ export const chainConfig = [
     },
   },
   {
+    network: "bob",
+    chainId: 60808,
+    urls: {
+      apiURL: "https://explorer.gobob.xyz/api",
+      browserURL: "https://explorer.gobob.xyz",
+    },
+  },
+  {
     network: "polygonMumbai",
     chainId: 80001,
     urls: {
@@ -237,6 +261,14 @@ export const chainConfig = [
     urls: {
       apiURL: "https://api-sepolia.arbiscan.io/api",
       browserURL: "https://sepolia.arbiscan.io/",
+    },
+  },
+  {
+    network: "bobSepolia",
+    chainId: 808813,
+    urls: {
+      apiURL: "https://bob-sepolia.explorer.gobob.xyz/api",
+      browserURL: "https://bob-sepolia.explorer.gobob.xyz",
     },
   },
   {

--- a/src/artifact/internal/etherscan.ts
+++ b/src/artifact/internal/etherscan.ts
@@ -155,7 +155,7 @@ export async function getSourceCode({
 }
 
 /**
- * Checks if the given URL is reachable.
+ * Checks if the given URL is reachable using HEAD first, then OPTIONS.
  *
  * @param {string} url - The URL to check.
  * @returns {Promise<boolean>} True if the URL is reachable, false otherwise.
@@ -163,9 +163,16 @@ export async function getSourceCode({
 async function isLiveUrl(url: string): Promise<boolean> {
   try {
     const response = await fetch(url, { method: "HEAD" });
-    return response.ok;
+    if (response.ok) return true;
   } catch (error) {
-    console.error(`Error pinging ${url}:`, error);
+    console.warn(`HEAD request failed for ${url}, trying OPTIONS...`);
+  }
+
+  try {
+    const response = await fetch(url, { method: "OPTIONS" });
+    return response.status < 500;
+  } catch (error) {
+    console.error(`Both HEAD and OPTIONS failed for ${url}:`, error);
     return false;
   }
 }

--- a/src/tooling/deployFactories.ts
+++ b/src/tooling/deployFactories.ts
@@ -102,6 +102,7 @@ async function deployKnownFactory({
       method: "eth_getCode",
       params: [factoryAddress, "latest"],
     });
+
     if (code != "0x") {
       return;
     }


### PR DESCRIPTION
## **Description:**

This PR introduces support for the following networks:
- **Lisk**
- **Lisk Sepolia**
- **Bob**
- **Bob Sepolia**

Additionally, it enhances URL reachability checks by implementing a fallback mechanism. Since some servers block **HEAD** requests, the **OPTIONS** method is now used as a secondary validation method.

---

### **Changes:**

1. **Added new network configurations** to `src/artifact/internal/chainConfig.ts`:
   - `Lisk` (chainId: 1135)
   - `Lisk Sepolia` (chainId: 4202)
   - `Bob` (chainId: 60808)
   - `Bob Sepolia` (chainId: 808813)

2. **Enhanced network URL validation** in `src/artifact/internal/etherscan.ts`:
   - Primary check with `HEAD` request.
   - If `HEAD` fails, fallback to `OPTIONS` request.
   - Improved error handling and logging.

3. **Updated versioning in `package.json`**:
   - Incremented package version from **2.0.4** to **2.0.5**.

4. **Updated `.gitignore`**:
   - Added `.vscode/settings.json` to avoid committing local VS Code settings.

---

### **Testing & Validation:**
- Confirmed that all added networks return valid responses.
- Ensured that fallback to `OPTIONS` works when `HEAD` requests are blocked.
- Verified no breaking changes to existing functionality.

