### PR TITLE
Fix: Use custom factory for singleton deployment

### DIFF
--- a/src/tooling/deployMastercopy.ts
+++ b/src/tooling/deployMastercopy.ts
@@ -76,6 +76,7 @@ export default async function deployMastercopy({
 
   const transaction = {
     ...encodeDeploySingleton({
+      factory,
       bytecode,
       constructorArgs,
       salt,


### PR DESCRIPTION
  - Fixes deployment to properly use the passed-in factory parameter when encoding singleton deployments
  - Previously the factory parameter was accepted but not utilized in the encodeDeploySingleton call, only in predicting